### PR TITLE
feat: implement natural song end handling and auto-advance functionality

### DIFF
--- a/src/hooks/useAudioPlayback.ts
+++ b/src/hooks/useAudioPlayback.ts
@@ -12,13 +12,11 @@ const TIME_POLL_INTERVAL_MS = 250;
 function createAudioEventHandlers(
     getAudioManager: () => AudioManager | null,
     onNaturalEndRef: { current: (() => void) | undefined },
+    resetPlaybackStateRef: { current: () => void },
     setState: {
         setIsPlaying: (value: boolean) => void;
         setPlayingSong: (value: Song | null) => void;
         setIsStopping: (value: boolean) => void;
-        setCurrentTime: (value: number) => void;
-        setDuration: (value: number | null) => void;
-        markEndedOrStopped: () => void;
     }
 ) {
     return {
@@ -26,12 +24,7 @@ function createAudioEventHandlers(
             // Only reset timing and clear playing state if the ended channel is the active one
             const audioManager = getAudioManager();
             if (id === audioManager?.getActiveChannelId()) {
-                setState.markEndedOrStopped();
-                setState.setIsPlaying(false);
-                setState.setPlayingSong(null);
-                setState.setIsStopping(false);
-                setState.setCurrentTime(0);
-                setState.setDuration(null);
+                resetPlaybackStateRef.current();
                 onNaturalEndRef.current?.();
             }
         },
@@ -47,11 +40,7 @@ function createAudioEventHandlers(
         onFadeFinished: (id: AudioChannel) => {
             const audioManager = getAudioManager();
             if (id === audioManager?.getActiveChannelId()) {
-                setState.setIsPlaying(false);
-                setState.setPlayingSong(null);
-                setState.setIsStopping(false);
-                setState.setCurrentTime(0);
-                setState.setDuration(null);
+                resetPlaybackStateRef.current();
             }
         }
     };
@@ -116,20 +105,26 @@ export function useAudioPlayback(onNaturalEnd?: () => void) {
     const onNaturalEndRef = useRef(onNaturalEnd);
     useEffect(() => { onNaturalEndRef.current = onNaturalEnd; }, [onNaturalEnd]);
 
+    // Stable ref for full playback reset — captured by handlers created in the useState lazy init
+    // and reused by the polling fallback. Safe because all closed-over values (React setters,
+    // endedOrStoppedRef) are stable references guaranteed by React.
+    const resetPlaybackStateRef = useRef(() => {
+        endedOrStoppedRef.current = true;
+        setIsPlaying(false);
+        setPlayingSong(null);
+        setIsStopping(false);
+        setCurrentTime(0);
+        setDuration(null);
+    });
+
     // Initialize AudioManager with lazy initializer (proper React pattern)
     const [audioManager] = useState(() => {
         const audioManagerRef = { current: null as AudioManager | null };
         const handlers = createAudioEventHandlers(
             () => audioManagerRef.current,
             onNaturalEndRef,
-            {
-                setIsPlaying,
-                setPlayingSong,
-                setIsStopping,
-                setCurrentTime,
-                setDuration,
-                markEndedOrStopped: () => { endedOrStoppedRef.current = true; }
-            }
+            resetPlaybackStateRef,
+            { setIsPlaying, setPlayingSong, setIsStopping }
         );
         const manager = new AudioManager(handlers);
         audioManagerRef.current = manager;
@@ -145,12 +140,7 @@ export function useAudioPlayback(onNaturalEnd?: () => void) {
             isPlaying,
             { setCurrentTime, setDuration },
             () => {
-                endedOrStoppedRef.current = true;
-                setIsPlaying(false);
-                setPlayingSong(null);
-                setIsStopping(false);
-                setCurrentTime(0);
-                setDuration(null);
+                resetPlaybackStateRef.current();
                 onNaturalEndRef.current?.();
             }
         );
@@ -195,12 +185,8 @@ export function useAudioPlayback(onNaturalEnd?: () => void) {
 
     const stop = useCallback(() => {
         audioManager.stopWithFade();
-        setIsPlaying(false);
-        setPlayingSong(null);
-        setIsStopping(true);
-        setCurrentTime(0);
-        setDuration(null);
-        endedOrStoppedRef.current = true;
+        resetPlaybackStateRef.current();
+        setIsStopping(true); // override: track that a fade-stop is in progress
     }, [audioManager]);
 
     const getAudioElement = useCallback(() => {

--- a/src/hooks/useAudioPlayback.ts
+++ b/src/hooks/useAudioPlayback.ts
@@ -11,12 +11,14 @@ const TIME_POLL_INTERVAL_MS = 250;
  */
 function createAudioEventHandlers(
     getAudioManager: () => AudioManager | null,
+    onNaturalEndRef: { current: (() => void) | undefined },
     setState: {
         setIsPlaying: (value: boolean) => void;
         setPlayingSong: (value: Song | null) => void;
         setIsStopping: (value: boolean) => void;
         setCurrentTime: (value: number) => void;
         setDuration: (value: number | null) => void;
+        markEndedOrStopped: () => void;
     }
 ) {
     return {
@@ -24,11 +26,13 @@ function createAudioEventHandlers(
             // Only reset timing and clear playing state if the ended channel is the active one
             const audioManager = getAudioManager();
             if (id === audioManager?.getActiveChannelId()) {
+                setState.markEndedOrStopped();
                 setState.setIsPlaying(false);
                 setState.setPlayingSong(null);
                 setState.setIsStopping(false);
                 setState.setCurrentTime(0);
                 setState.setDuration(null);
+                onNaturalEndRef.current?.();
             }
         },
         onError: (id: AudioChannel, err: any) => {
@@ -56,6 +60,7 @@ function createAudioEventHandlers(
 /**
  * Polls the active audio element for timing updates.
  * Avoids overwriting reset state when playback has ended or been stopped.
+ * Also acts as a fallback detector for natural song end when the 'ended' event is unreliable.
  */
 function createTimingTick(
     audioManager: AudioManager,
@@ -64,7 +69,8 @@ function createTimingTick(
     setState: {
         setCurrentTime: (value: number) => void;
         setDuration: (value: number | null) => void;
-    }
+    },
+    onNaturalEnd: () => void
 ) {
     return (mounted: { current: boolean }) => {
         const audio = audioManager.getActiveAudio();
@@ -72,6 +78,13 @@ function createTimingTick(
 
         // If we've recently ended/stopped, don't overwrite the reset
         if (endedOrStoppedRef.current) return;
+
+        // Fallback: detect natural end when the 'ended' event didn't fire (e.g. some WebViews)
+        if (audio.ended && isPlaying) {
+            if (!mounted.current) return;
+            onNaturalEnd();
+            return;
+        }
 
         // If audio is paused and we are not in playing state, keep times reset
         if (audio.paused && !isPlaying) {
@@ -89,7 +102,7 @@ function createTimingTick(
     };
 }
 
-export function useAudioPlayback() {
+export function useAudioPlayback(onNaturalEnd?: () => void) {
     const [playingSong, setPlayingSong] = useState<Song | null>(null);
     const [isPlaying, setIsPlaying] = useState(false);
     const [isStopping, setIsStopping] = useState(false);
@@ -99,12 +112,24 @@ export function useAudioPlayback() {
     // Ref to indicate we've recently ended/stopped playback so polling shouldn't overwrite resets
     const endedOrStoppedRef = useRef(false);
 
+    // Keep the external callback in a ref so handlers created once can always see the latest version
+    const onNaturalEndRef = useRef(onNaturalEnd);
+    useEffect(() => { onNaturalEndRef.current = onNaturalEnd; }, [onNaturalEnd]);
+
     // Initialize AudioManager with lazy initializer (proper React pattern)
     const [audioManager] = useState(() => {
         const audioManagerRef = { current: null as AudioManager | null };
         const handlers = createAudioEventHandlers(
             () => audioManagerRef.current,
-            { setIsPlaying, setPlayingSong, setIsStopping, setCurrentTime, setDuration }
+            onNaturalEndRef,
+            {
+                setIsPlaying,
+                setPlayingSong,
+                setIsStopping,
+                setCurrentTime,
+                setDuration,
+                markEndedOrStopped: () => { endedOrStoppedRef.current = true; }
+            }
         );
         const manager = new AudioManager(handlers);
         audioManagerRef.current = manager;
@@ -118,7 +143,16 @@ export function useAudioPlayback() {
             audioManager,
             endedOrStoppedRef,
             isPlaying,
-            { setCurrentTime, setDuration }
+            { setCurrentTime, setDuration },
+            () => {
+                endedOrStoppedRef.current = true;
+                setIsPlaying(false);
+                setPlayingSong(null);
+                setIsStopping(false);
+                setCurrentTime(0);
+                setDuration(null);
+                onNaturalEndRef.current?.();
+            }
         );
 
         const interval = window.setInterval(() => {

--- a/src/hooks/useMusicPlayer.ts
+++ b/src/hooks/useMusicPlayer.ts
@@ -25,7 +25,7 @@ export function useMusicPlayer(fileService?: FileService) {
 
     const { loadPlaylist: loadPlaylistFiles } = useFileLoader(fileService);
 
-    const handleSongNaturallyEnded = useCallback(() => {
+    const selectNextSongOnEnd = useCallback(() => {
         const nextSong = peekNextSong();
         if (nextSong) {
             setSelectedSongState(nextSong);
@@ -44,7 +44,7 @@ export function useMusicPlayer(fileService?: FileService) {
         pause: pauseAudio,
         stop: stopAudio,
         getAudioElement
-    } = useAudioPlayback(handleSongNaturallyEnded);
+    } = useAudioPlayback(selectNextSongOnEnd);
 
     // Coordination functions that bridge between different domain hooks
 

--- a/src/hooks/useMusicPlayer.ts
+++ b/src/hooks/useMusicPlayer.ts
@@ -19,10 +19,18 @@ export function useMusicPlayer(fileService?: FileService) {
         setPlaylist: setPlaylistState,
         setSelectedSong: setSelectedSongState,
         selectNext,
-        selectPrevious
+        selectPrevious,
+        peekNextSong
     } = usePlaylistState();
 
     const { loadPlaylist: loadPlaylistFiles } = useFileLoader(fileService);
+
+    const handleSongNaturallyEnded = useCallback(() => {
+        const nextSong = peekNextSong();
+        if (nextSong) {
+            setSelectedSongState(nextSong);
+        }
+    }, [peekNextSong, setSelectedSongState]);
 
     const {
         playingSong,
@@ -34,8 +42,9 @@ export function useMusicPlayer(fileService?: FileService) {
         playedPercent,
         play: playAudio,
         pause: pauseAudio,
-        stop: stopAudio
-    } = useAudioPlayback();
+        stop: stopAudio,
+        getAudioElement
+    } = useAudioPlayback(handleSongNaturallyEnded);
 
     // Coordination functions that bridge between different domain hooks
 
@@ -86,6 +95,7 @@ export function useMusicPlayer(fileService?: FileService) {
         stop: stopAudio,
         selectNextInList: selectNext,
         selectPreviousInList: selectPrevious,
+        getAudioElement,
         // timing info
         currentTime,
         duration,

--- a/src/hooks/usePlaylistState.ts
+++ b/src/hooks/usePlaylistState.ts
@@ -44,12 +44,17 @@ export function usePlaylistState() {
         }
     }, []);
 
+    const peekNextSong = useCallback((): Song | null => {
+        return playlistManagerRef.current.peekNext();
+    }, []);
+
     return {
         playlist,
         selectedSong,
         setPlaylist,
         setSelectedSong,
         selectNext,
-        selectPrevious
+        selectPrevious,
+        peekNextSong
     };
 }

--- a/src/logic/PlaylistManager.ts
+++ b/src/logic/PlaylistManager.ts
@@ -33,6 +33,14 @@ export class PlaylistManager {
         return this.songs[this.currentIndex]; // Stay at end
     }
 
+    /** Returns the next song without advancing the index. Returns null if already at the last song. */
+    public peekNext(): Song | null {
+        if (this.currentIndex < this.songs.length - 1) {
+            return this.songs[this.currentIndex + 1];
+        }
+        return null;
+    }
+
     public getPrevious(): Song | null {
         if (this.songs.length === 0) return null;
         if (this.currentIndex > 0) {

--- a/test/hooks/useAudioPlayback.test.ts
+++ b/test/hooks/useAudioPlayback.test.ts
@@ -258,6 +258,149 @@ describe("useAudioPlayback", () => {
         });
     });
 
+    describe("natural song end (audio 'ended' event)", () => {
+        it("should reset all state when audio fires 'ended' event", () => {
+            const { result } = renderHook(() => useAudioPlayback());
+            const song = new Song("test.mp3");
+
+            act(() => {
+                result.current.play(song);
+            });
+
+            expect(result.current.isPlaying).toBe(true);
+            expect(result.current.playingSong).toBe(song);
+
+            const audioElement = result.current.getAudioElement();
+            Object.defineProperty(audioElement, 'paused', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'ended', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'currentTime', { value: 180, configurable: true });
+            Object.defineProperty(audioElement, 'duration', { value: 180, configurable: true });
+
+            act(() => {
+                audioElement.dispatchEvent(new Event("ended"));
+            });
+
+            expect(result.current.isPlaying).toBe(false);
+            expect(result.current.playingSong).toBeNull();
+            expect(result.current.isStopping).toBe(false);
+            expect(result.current.currentTime).toBe(0);
+            expect(result.current.duration).toBeNull();
+        });
+
+        it("should not overwrite reset state after natural end (timer must not interfere)", () => {
+            const { result } = renderHook(() => useAudioPlayback());
+            const song = new Song("test.mp3");
+
+            act(() => {
+                result.current.play(song);
+            });
+
+            const audioElement = result.current.getAudioElement();
+            Object.defineProperty(audioElement, 'paused', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'ended', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'currentTime', { value: 180, configurable: true });
+            Object.defineProperty(audioElement, 'duration', { value: 180, configurable: true });
+
+            act(() => {
+                audioElement.dispatchEvent(new Event("ended"));
+            });
+
+            // Polling should NOT overwrite the reset
+            act(() => {
+                vi.advanceTimersByTime(500);
+            });
+
+            expect(result.current.isPlaying).toBe(false);
+            expect(result.current.playingSong).toBeNull();
+            expect(result.current.currentTime).toBe(0);
+            expect(result.current.duration).toBeNull();
+        });
+
+        it("should reset state via timer fallback when 'ended' event never fires", () => {
+            const { result } = renderHook(() => useAudioPlayback());
+            const song = new Song("test.mp3");
+
+            act(() => {
+                result.current.play(song);
+            });
+
+            // Simulate audio that has ended (audio.ended = true) but the 'ended' event
+            // never fired (edge case in some WebViews / Tauri)
+            const audioElement = result.current.getAudioElement();
+            Object.defineProperty(audioElement, 'paused', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'ended', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'currentTime', { value: 180, configurable: true });
+            Object.defineProperty(audioElement, 'duration', { value: 180, configurable: true });
+
+            // No dispatchEvent("ended") — only allow the timer to detect it
+            act(() => {
+                vi.advanceTimersByTime(250);
+            });
+
+            expect(result.current.isPlaying).toBe(false);
+            expect(result.current.playingSong).toBeNull();
+            expect(result.current.isStopping).toBe(false);
+            expect(result.current.currentTime).toBe(0);
+            expect(result.current.duration).toBeNull();
+        });
+    });
+
+    describe("onNaturalEnd callback", () => {
+        it("should invoke the callback when audio fires 'ended' event", () => {
+            const onNaturalEnd = vi.fn();
+            const { result } = renderHook(() => useAudioPlayback(onNaturalEnd));
+            const song = new Song("test.mp3");
+
+            act(() => {
+                result.current.play(song);
+            });
+
+            const audioElement = result.current.getAudioElement();
+            act(() => {
+                audioElement.dispatchEvent(new Event("ended"));
+            });
+
+            expect(onNaturalEnd).toHaveBeenCalledTimes(1);
+        });
+
+        it("should invoke the callback via timer fallback when 'ended' event never fires", () => {
+            const onNaturalEnd = vi.fn();
+            const { result } = renderHook(() => useAudioPlayback(onNaturalEnd));
+            const song = new Song("test.mp3");
+
+            act(() => {
+                result.current.play(song);
+            });
+
+            const audioElement = result.current.getAudioElement();
+            Object.defineProperty(audioElement, 'paused', { value: true, configurable: true });
+            Object.defineProperty(audioElement, 'ended', { value: true, configurable: true });
+
+            act(() => {
+                vi.advanceTimersByTime(250);
+            });
+
+            expect(onNaturalEnd).toHaveBeenCalledTimes(1);
+        });
+
+        it("should NOT invoke the callback when user explicitly stops playback", () => {
+            const onNaturalEnd = vi.fn();
+            const { result } = renderHook(() => useAudioPlayback(onNaturalEnd));
+            const song = new Song("test.mp3");
+
+            act(() => {
+                result.current.play(song);
+                result.current.stop();
+            });
+
+            act(() => {
+                vi.advanceTimersByTime(500);
+            });
+
+            expect(onNaturalEnd).not.toHaveBeenCalled();
+        });
+    });
+
     describe("channel switching and race conditions", () => {
         it("should handle rapid song switches", () => {
             const { result } = renderHook(() => useAudioPlayback());

--- a/test/hooks/useMusicPlayer.test.ts
+++ b/test/hooks/useMusicPlayer.test.ts
@@ -243,6 +243,69 @@ describe("useMusicPlayer", () => {
         expect(result.current.isPlaying).toBe(false);
     });
 
+    describe("auto-advance on natural song end", () => {
+        it("should select the next song (without playing) when the current one ends naturally", async () => {
+            const s1 = new Song("s1.mp3");
+            const s2 = new Song("s2.mp3");
+            const mockFileService = createMockFileService({ songs: [s1, s2], name: "pl" });
+            const { result } = renderHook(() => useMusicPlayer(mockFileService));
+
+            await act(async () => { await result.current.loadPlaylist(); });
+
+            act(() => { result.current.playSong(s1); });
+            expect(result.current.playingSong).toBe(s1);
+
+            // Simulate natural end of s1
+            const audioElement = result.current.getAudioElement();
+            act(() => {
+                audioElement.dispatchEvent(new Event("ended"));
+            });
+
+            expect(result.current.isPlaying).toBe(false);
+            expect(result.current.playingSong).toBeNull();
+            expect(result.current.selectedSong).toBe(s2);
+        });
+
+        it("should stop playback when last song ends naturally (no auto-advance)", async () => {
+            const s1 = new Song("s1.mp3");
+            const s2 = new Song("s2.mp3");
+            const mockFileService = createMockFileService({ songs: [s1, s2], name: "pl" });
+            const { result } = renderHook(() => useMusicPlayer(mockFileService));
+
+            await act(async () => { await result.current.loadPlaylist(); });
+
+            act(() => { result.current.playSong(s2); });
+            expect(result.current.playingSong).toBe(s2);
+
+            // Simulate natural end of s2 (the last song)
+            const audioElement = result.current.getAudioElement();
+            act(() => {
+                audioElement.dispatchEvent(new Event("ended"));
+            });
+
+            expect(result.current.isPlaying).toBe(false);
+            expect(result.current.playingSong).toBeNull();
+        });
+
+        it("should stop playback when only one song in the playlist ends naturally", async () => {
+            const s1 = new Song("s1.mp3");
+            const mockFileService = createMockFileService({ songs: [s1], name: "pl" });
+            const { result } = renderHook(() => useMusicPlayer(mockFileService));
+
+            await act(async () => { await result.current.loadPlaylist(); });
+
+            act(() => { result.current.playSong(s1); });
+
+            const audioElement = result.current.getAudioElement();
+            act(() => {
+                audioElement.dispatchEvent(new Event("ended"));
+            });
+
+            expect(result.current.isPlaying).toBe(false);
+            expect(result.current.playingSong).toBeNull();
+        });
+    });
+
     it("should not play invalid song when using playCurrentSelected", () => {
         const mockFileService = createMockFileService({
             songs: [new Song("invalid.mp3", false)],

--- a/test/logic/PlaylistManager.test.ts
+++ b/test/logic/PlaylistManager.test.ts
@@ -57,6 +57,33 @@ describe("PlaylistManager", () => {
         expect(manager.getPrevious()).toBeNull();
     });
 
+    describe("peekNext", () => {
+        it("should return the next song without advancing the index", () => {
+            const s1 = new Song("s1.mp3");
+            const s2 = new Song("s2.mp3");
+            manager.setSongs([s1, s2]);
+
+            const peeked = manager.peekNext();
+
+            expect(peeked).toBe(s2);
+            // Index must NOT have advanced
+            expect(manager.getCurrentSong()).toBe(s1);
+        });
+
+        it("should return null when at the last song", () => {
+            const s1 = new Song("s1.mp3");
+            const s2 = new Song("s2.mp3");
+            manager.setSongs([s1, s2]);
+            manager.setCurrentSong(s2);
+
+            expect(manager.peekNext()).toBeNull();
+        });
+
+        it("should return null when the playlist is empty", () => {
+            expect(manager.peekNext()).toBeNull();
+        });
+    });
+
     it("should reset current song when setting empty songs array", () => {
         manager.setSongs([new Song("s1.mp3")]);
         expect(manager.getCurrentSong()).not.toBeNull();


### PR DESCRIPTION
This pull request improves the robustness and user experience of audio playback and playlist management by ensuring correct behavior when a song ends naturally, including reliable state resets and auto-advancing to the next song when appropriate. It introduces a fallback for unreliable 'ended' events, adds a new `peekNext` method for playlists, and thoroughly tests these scenarios.

**Audio playback and natural song end handling:**

- Refactored `useAudioPlayback` to reliably detect natural song ends, even when the audio element's 'ended' event is unreliable (e.g., in some WebViews), by adding a polling-based fallback. State resets and external callbacks are now handled consistently via stable refs. [[1]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfR14-R28) [[2]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfL46-R43) [[3]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfR52) [[4]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfL67-R62) [[5]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfR71-R77) [[6]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfL92-R94) [[7]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfR104-R127) [[8]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfL121-R145) [[9]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfL164-R189)

- Added an `onNaturalEnd` callback parameter to `useAudioPlayback`, invoked when a song ends naturally (either via event or fallback), and ensured it is not called when playback is stopped explicitly by the user. [[1]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfR104-R127) [[2]](diffhunk://#diff-e106a4b3a1fa8d4d85ebb914bb4061a4794932eb8882a450264df832887242cfL121-R145) [[3]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628L37-R47) [[4]](diffhunk://#diff-498c3f70c14116bea540b1b9a70a6de1496e0f322618d8516041f6205de19a99R261-R403)

**Playlist management and auto-advance:**

- Added a `peekNext` method to `PlaylistManager` and exposed it through `usePlaylistState`, allowing the next song to be determined without advancing the playlist index. [[1]](diffhunk://#diff-e2230c2b1133709857d4d450059a1796d014e8aadb2a6545b4728f57cacc90c9R36-R43) [[2]](diffhunk://#diff-e22471f3b1fafcc886b8c278a4ac43a5cdcca7796b6d718cc553f22be671737cR47-R58)

- Updated `useMusicPlayer` to auto-select the next song in the playlist (but not auto-play) when the current song ends naturally, using the new `peekNextSong` logic. Playback stops if there is no next song. [[1]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628L22-R34) [[2]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628L37-R47) [[3]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628R98)

**Testing improvements:**

- Added comprehensive tests for natural song end handling, including fallback detection, state reset correctness, and `onNaturalEnd` callback invocation in `useAudioPlayback`.

- Added tests for auto-advance behavior in `useMusicPlayer` and for the new `peekNext` method in `PlaylistManager`. [[1]](diffhunk://#diff-ede3fe1cfaca98667a0da018cceebfe76710f356841d84b82fc6bce2314d7b2fR246-R308) [[2]](diffhunk://#diff-bbc208793d5238198e0fdb65ddcf72b76a6b5c4f7780a6a9ad9a6935216d25f7R60-R86)