### PR TITLE
feat: add song removal functionality and unsaved changes indicator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -610,6 +610,15 @@ body {
   text-overflow: ellipsis;
 }
 
+.unsaved-dot {
+  font-size: 10px;
+  color: var(--apple-text-secondary);
+  flex-shrink: 0;
+  margin-right: 4px;
+  line-height: 1;
+  align-self: center;
+}
+
 .btn-change-playlist {
   background: rgba(0, 0, 0, 0.05);
   border: 1px solid var(--apple-border);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ function App() {
     playlist,
     currentPlaylistName,
     selectedSong,
+    hasUnsavedChanges,
     playingSong,
     isPlaying,
     isStopping,
@@ -23,6 +24,7 @@ function App() {
     playCurrentSelected,
     pause,
     stop,
+    removeSong,
     selectNextInList,
     selectPreviousInList,
     currentTime,
@@ -53,6 +55,10 @@ function App() {
       console.error("Failed to reveal in explorer:", error);
     }
   }, []);
+
+  const handleRemoveSong = useCallback((song: Song) => {
+    removeSong(song);
+  }, [removeSong]);
 
   const toggleSidebar = useCallback(() => setIsSidebarCompact(prev => !prev), []);
 
@@ -101,11 +107,13 @@ function App() {
         playingSong={playingSong}
         isPlaying={isPlaying}
         currentPlaylistName={currentPlaylistName}
+        hasUnsavedChanges={hasUnsavedChanges}
         onSelectSong={setSelectedSong}
         onPlaySong={playSong}
         onLoadPlaylist={handleLoadPlaylist}
         onChangePlaylist={handleChangePlaylist}
         onRevealInExplorer={handleRevealInExplorer}
+        onRemoveSong={handleRemoveSong}
       />
 
       <ShortcutsFooter />

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -115,7 +115,7 @@ export function Sidebar({ isCompact = false, onCollapse }: SidebarProps = {}) {
                     </div>
                     <div className="sidebar-compact-bottom">
                         {onCollapse && (
-                            <button className="sidebar-collapse-btn sidebar-collapse-btn--compact" onClick={onCollapse} title="Expandir sidebar" aria-label="Expandir sidebar">
+                            <button className="sidebar-collapse-btn sidebar-collapse-btn--compact" onClick={onCollapse} title="Expandir Biblioteca" aria-label="Expandir Biblioteca">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                                     <polyline points="13 17 18 12 13 7"></polyline>
                                     <polyline points="6 17 11 12 6 7"></polyline>
@@ -169,7 +169,7 @@ export function Sidebar({ isCompact = false, onCollapse }: SidebarProps = {}) {
                                 <polyline points="11 17 6 12 11 7"></polyline>
                                 <polyline points="18 17 13 12 18 7"></polyline>
                             </svg>
-                            Contraer
+                            Ocultar Biblioteca
                         </button>
                     )}
 

--- a/src/components/songList/PlaylistBanner.tsx
+++ b/src/components/songList/PlaylistBanner.tsx
@@ -18,7 +18,14 @@ export function PlaylistBanner({ currentPlaylistName, songsCount = 0, hasUnsaved
                             <div className="playlist-banner-name-row">
                                 <span className="playlist-banner-name" title={currentPlaylistName}>{currentPlaylistName}</span>
                                 {hasUnsavedChanges && (
-                                    <span className="unsaved-dot" title="Cambios sin guardar">●</span>
+                                    <span
+                                        className="unsaved-dot"
+                                        title="Cambios sin guardar"
+                                        role="img"
+                                        aria-label="Cambios sin guardar"
+                                    >
+                                        ●
+                                    </span>
                                 )}
                                 <span className="playlist-banner-count">{songsLabel}</span>
                             </div>

--- a/src/components/songList/PlaylistBanner.tsx
+++ b/src/components/songList/PlaylistBanner.tsx
@@ -1,11 +1,12 @@
 interface PlaylistBannerProps {
     currentPlaylistName: string | null;
     songsCount?: number;
+    hasUnsavedChanges?: boolean;
     onLoadPlaylist: () => void;
     onChangePlaylist?: () => void;
 }
 
-export function PlaylistBanner({ currentPlaylistName, songsCount = 0, onLoadPlaylist, onChangePlaylist }: PlaylistBannerProps) {
+export function PlaylistBanner({ currentPlaylistName, songsCount = 0, hasUnsavedChanges, onLoadPlaylist, onChangePlaylist }: PlaylistBannerProps) {
     const songsLabel = songsCount === 1 ? "1 canción" : `${songsCount} canciones`;
 
     return (
@@ -16,6 +17,9 @@ export function PlaylistBanner({ currentPlaylistName, songsCount = 0, onLoadPlay
                             <span className="playlist-banner-label">Lista de reproducción</span>
                             <div className="playlist-banner-name-row">
                                 <span className="playlist-banner-name" title={currentPlaylistName}>{currentPlaylistName}</span>
+                                {hasUnsavedChanges && (
+                                    <span className="unsaved-dot" title="Cambios sin guardar">●</span>
+                                )}
                                 <span className="playlist-banner-count">{songsLabel}</span>
                             </div>
                         </div>

--- a/src/components/songList/SongList.tsx
+++ b/src/components/songList/SongList.tsx
@@ -10,14 +10,16 @@ interface SongListProps {
     playingSong: Song | null;
     isPlaying: boolean;
     currentPlaylistName: string | null;
+    hasUnsavedChanges?: boolean;
     onSelectSong: (song: Song) => void;
     onPlaySong: (song: Song) => void;
     onLoadPlaylist: () => void;
     onChangePlaylist?: () => void;
     onRevealInExplorer?: (song: Song) => void;
+    onRemoveSong?: (song: Song) => void;
 }
 
-export function SongList({ playlist, selectedSong, playingSong, isPlaying, currentPlaylistName, onSelectSong, onPlaySong, onLoadPlaylist, onChangePlaylist, onRevealInExplorer }: SongListProps) {
+export function SongList({ playlist, selectedSong, playingSong, isPlaying, currentPlaylistName, hasUnsavedChanges, onSelectSong, onPlaySong, onLoadPlaylist, onChangePlaylist, onRevealInExplorer, onRemoveSong }: SongListProps) {
     const selectedRowRef = useRef<HTMLTableRowElement | null>(null);
 
     useEffect(() => {
@@ -36,6 +38,7 @@ export function SongList({ playlist, selectedSong, playingSong, isPlaying, curre
                 songsCount={playlist.length}
                 onLoadPlaylist={onLoadPlaylist}
                 onChangePlaylist={onChangePlaylist}
+                hasUnsavedChanges={hasUnsavedChanges}
             />
             {playlist.length === 0 ? (
                 <EmptyPlaylist />
@@ -51,9 +54,11 @@ export function SongList({ playlist, selectedSong, playingSong, isPlaying, curre
                                     song={song}
                                     isSelected={isSelected}
                                     isPlaying={isReallyPlaying}
+                                    isPlayingSong={isReallyPlaying}
                                     onSelect={onSelectSong}
                                     onPlay={onPlaySong}
                                     onRevealInExplorer={onRevealInExplorer}
+                                    onRemoveSong={onRemoveSong}
                                     ref={isSelected ? selectedRowRef : null}
                                 />
                             );

--- a/src/components/songList/SongList.tsx
+++ b/src/components/songList/SongList.tsx
@@ -47,14 +47,15 @@ export function SongList({ playlist, selectedSong, playingSong, isPlaying, curre
                     <tbody>
                         {playlist.map((song) => {
                             const isSelected = song.equals(selectedSong);
-                            const isReallyPlaying = song.equals(playingSong) && isPlaying;
+                            const isLoadedSong = song.equals(playingSong);
+                            const isReallyPlaying = isLoadedSong && isPlaying;
                             return (
                                 <SongRow
                                     key={song.getPath()}
                                     song={song}
                                     isSelected={isSelected}
                                     isPlaying={isReallyPlaying}
-                                    isPlayingSong={isReallyPlaying}
+                                    isPlayingSong={isLoadedSong}
                                     onSelect={onSelectSong}
                                     onPlay={onPlaySong}
                                     onRevealInExplorer={onRevealInExplorer}

--- a/src/components/songList/SongRow.tsx
+++ b/src/components/songList/SongRow.tsx
@@ -7,21 +7,28 @@ interface SongRowProps {
     song: Song;
     isSelected: boolean;
     isPlaying: boolean;
+    isPlayingSong?: boolean;
     onSelect: (song: Song) => void;
     onPlay: (song: Song) => void;
     onRevealInExplorer?: (song: Song) => void;
+    onRemoveSong?: (song: Song) => void;
 }
 
 export const SongRow = forwardRef<HTMLTableRowElement, SongRowProps>(
-    ({ song, isSelected, isPlaying, onSelect, onPlay, onRevealInExplorer }, ref) => {
+    ({ song, isSelected, isPlaying, isPlayingSong, onSelect, onPlay, onRevealInExplorer, onRemoveSong }, ref) => {
         const isInvalid = !song.isValid();
         const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
 
         const handleContextMenu = (e: React.MouseEvent) => {
-            if (!onRevealInExplorer) return;
+            if (!onRevealInExplorer && !onRemoveSong) return;
             e.preventDefault();
             setContextMenuPos({ x: e.clientX, y: e.clientY });
         };
+
+        const contextMenuItems = [
+            ...(onRemoveSong ? [{ label: "Eliminar de la lista", disabled: isPlayingSong, onClick: () => onRemoveSong(song) }] : []),
+            ...(onRevealInExplorer ? [{ label: "Mostrar en el Explorador", disabled: isInvalid, onClick: () => onRevealInExplorer(song) }] : []),
+        ];
 
         return (
             <>
@@ -53,11 +60,11 @@ export const SongRow = forwardRef<HTMLTableRowElement, SongRowProps>(
                     </div>
                 </td>
             </tr>
-            {contextMenuPos && onRevealInExplorer && createPortal(
+            {contextMenuPos && createPortal(
                 <ContextMenu
                     x={contextMenuPos.x}
                     y={contextMenuPos.y}
-                    items={[{ label: "Mostrar en el Explorador", disabled: isInvalid, onClick: () => onRevealInExplorer(song) }]}
+                    items={contextMenuItems}
                     onClose={() => setContextMenuPos(null)}
                 />,
                 document.body

--- a/src/hooks/useMusicPlayer.ts
+++ b/src/hooks/useMusicPlayer.ts
@@ -16,8 +16,10 @@ export function useMusicPlayer(fileService?: FileService) {
     const {
         playlist,
         selectedSong,
+        hasUnsavedChanges,
         setPlaylist: setPlaylistState,
         setSelectedSong: setSelectedSongState,
+        removeSong,
         selectNext,
         selectPrevious,
         peekNextSong
@@ -84,6 +86,7 @@ export function useMusicPlayer(fileService?: FileService) {
         playlist,
         currentPlaylistName,
         selectedSong,
+        hasUnsavedChanges,
         playingSong,
         isPlaying,
         isStopping,
@@ -93,6 +96,7 @@ export function useMusicPlayer(fileService?: FileService) {
         playCurrentSelected,
         pause: pauseAudio,
         stop: stopAudio,
+        removeSong,
         selectNextInList: selectNext,
         selectPreviousInList: selectPrevious,
         getAudioElement,

--- a/src/hooks/usePlaylistState.ts
+++ b/src/hooks/usePlaylistState.ts
@@ -5,11 +5,15 @@ import { Song } from "../logic/Song";
 export function usePlaylistState() {
     const [playlist, setPlaylistState] = useState<Song[]>([]);
     const [selectedSong, setSelectedSongState] = useState<Song | null>(null);
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     const playlistManagerRef = useRef(new PlaylistManager());
+    const playlistRef = useRef<Song[]>([]);
 
     const setPlaylist = useCallback((songs: Song[]) => {
+        playlistRef.current = songs;
         playlistManagerRef.current.setSongs(songs);
         setPlaylistState(songs);
+        setHasUnsavedChanges(false);
 
         // Auto-select first song if no song is selected and playlist is not empty
         // Use functional update to avoid stale closure
@@ -21,6 +25,34 @@ export function usePlaylistState() {
             }
             return prev;
         });
+    }, []);
+
+    const removeSong = useCallback((song: Song) => {
+        const currentPlaylist = playlistRef.current;
+        const songIndex = currentPlaylist.findIndex(s => s.equals(song));
+        if (songIndex === -1) return;
+
+        const updated = currentPlaylist.filter(s => !s.equals(song));
+        playlistRef.current = updated;
+        setPlaylistState(updated);
+
+        setSelectedSongState(currentSelected => {
+            if (!currentSelected?.equals(song)) {
+                // Not removing the selected song; restore PlaylistManager position
+                playlistManagerRef.current.setSongs(updated);
+                if (currentSelected) playlistManagerRef.current.setCurrentSong(currentSelected);
+                return currentSelected;
+            }
+
+            // Removing the selected song; pick the song at the same index (or last)
+            playlistManagerRef.current.setSongs(updated);
+            if (updated.length === 0) return null;
+            const newSong = updated[Math.min(songIndex, updated.length - 1)];
+            playlistManagerRef.current.setCurrentSong(newSong);
+            return newSong;
+        });
+
+        setHasUnsavedChanges(true);
     }, []);
 
     const setSelectedSong = useCallback((song: Song | null) => {
@@ -51,8 +83,10 @@ export function usePlaylistState() {
     return {
         playlist,
         selectedSong,
+        hasUnsavedChanges,
         setPlaylist,
         setSelectedSong,
+        removeSong,
         selectNext,
         selectPrevious,
         peekNextSong

--- a/src/hooks/usePlaylistState.ts
+++ b/src/hooks/usePlaylistState.ts
@@ -36,24 +36,27 @@ export function usePlaylistState() {
         playlistRef.current = updated;
         setPlaylistState(updated);
 
-        setSelectedSongState(currentSelected => {
-            if (!currentSelected?.equals(song)) {
-                // Not removing the selected song; restore PlaylistManager position
-                playlistManagerRef.current.setSongs(updated);
-                if (currentSelected) playlistManagerRef.current.setCurrentSong(currentSelected);
-                return currentSelected;
-            }
+        const currentSelected = selectedSong;
+        let newSelected: Song | null = currentSelected;
 
+        if (currentSelected?.equals(song)) {
             // Removing the selected song; pick the song at the same index (or last)
-            playlistManagerRef.current.setSongs(updated);
-            if (updated.length === 0) return null;
-            const newSong = updated[Math.min(songIndex, updated.length - 1)];
-            playlistManagerRef.current.setCurrentSong(newSong);
-            return newSong;
-        });
+            if (updated.length === 0) {
+                newSelected = null;
+            } else {
+                newSelected = updated[Math.min(songIndex, updated.length - 1)];
+            }
+        }
 
+        // Keep PlaylistManager in sync with the updated playlist and selection
+        playlistManagerRef.current.setSongs(updated);
+        if (newSelected) {
+            playlistManagerRef.current.setCurrentSong(newSelected);
+        }
+
+        setSelectedSongState(newSelected);
         setHasUnsavedChanges(true);
-    }, []);
+    }, [selectedSong]);
 
     const setSelectedSong = useCallback((song: Song | null) => {
         setSelectedSongState(song);

--- a/test/components/songList/PlaylistBanner.test.tsx
+++ b/test/components/songList/PlaylistBanner.test.tsx
@@ -67,4 +67,49 @@ describe("PlaylistBanner", () => {
             expect(mockOnChangePlaylist).toHaveBeenCalledOnce();
         });
     });
+
+    describe("Unsaved changes indicator", () => {
+        it("should show an unsaved changes indicator when hasUnsavedChanges is true", () => {
+            render(
+                <PlaylistBanner
+                    currentPlaylistName="Mi Playlist"
+                    onLoadPlaylist={mockOnLoadPlaylist}
+                    hasUnsavedChanges={true}
+                />
+            );
+            expect(screen.getByTitle(/cambios sin guardar/i)).toBeInTheDocument();
+        });
+
+        it("should not show an unsaved changes indicator when hasUnsavedChanges is false", () => {
+            render(
+                <PlaylistBanner
+                    currentPlaylistName="Mi Playlist"
+                    onLoadPlaylist={mockOnLoadPlaylist}
+                    hasUnsavedChanges={false}
+                />
+            );
+            expect(screen.queryByTitle(/cambios sin guardar/i)).not.toBeInTheDocument();
+        });
+
+        it("should not show an unsaved changes indicator when hasUnsavedChanges is not provided", () => {
+            render(
+                <PlaylistBanner
+                    currentPlaylistName="Mi Playlist"
+                    onLoadPlaylist={mockOnLoadPlaylist}
+                />
+            );
+            expect(screen.queryByTitle(/cambios sin guardar/i)).not.toBeInTheDocument();
+        });
+
+        it("should not show the indicator when there is no playlist loaded", () => {
+            render(
+                <PlaylistBanner
+                    currentPlaylistName={null}
+                    onLoadPlaylist={mockOnLoadPlaylist}
+                    hasUnsavedChanges={true}
+                />
+            );
+            expect(screen.queryByTitle(/cambios sin guardar/i)).not.toBeInTheDocument();
+        });
+    });
 });

--- a/test/components/songList/SongList.test.tsx
+++ b/test/components/songList/SongList.test.tsx
@@ -65,6 +65,27 @@ describe("SongList", () => {
         });
     });
 
+    describe("Remove song", () => {
+        it("should disable 'Eliminar de la lista' for the loaded song even when playback is paused", async () => {
+            const { default: userEvent } = await import("@testing-library/user-event");
+            const user = userEvent.setup();
+            const song = new Song("song.mp3");
+            render(
+                <SongList
+                    {...defaultProps}
+                    playlist={[song]}
+                    playingSong={song}
+                    isPlaying={false}
+                    onRemoveSong={vi.fn()}
+                />
+            );
+            const row = screen.getByText("song.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            const item = screen.getByText("Eliminar de la lista").closest("li");
+            expect(item?.className).toContain("disabled");
+        });
+    });
+
     describe("Complex interactions", () => {
         it("should correctly render playing and selected different songs", () => {
             const song1 = new Song("song1.mp3");

--- a/test/components/songList/SongRow.test.tsx
+++ b/test/components/songList/SongRow.test.tsx
@@ -228,22 +228,116 @@ describe("SongRow", () => {
             expect(screen.queryByText("Mostrar en el Explorador")).not.toBeInTheDocument();
         });
 
-        it("should show a disabled reveal option when song is invalid", async () => {
+        it("should show context menu with 'Eliminar de la lista' when onRemoveSong is provided", async () => {
             const user = userEvent.setup();
-            const { container } = render(
+            render(
                 <SongRow
-                    song={new Song("missing.mp3", false)}
+                    song={new Song("song.mp3")}
                     isSelected={false}
                     isPlaying={false}
                     onSelect={mockOnSelect}
                     onPlay={mockOnPlay}
+                    onRemoveSong={vi.fn()}
+                />
+            );
+            const row = screen.getByText("song.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            expect(screen.getByText("Eliminar de la lista")).toBeInTheDocument();
+        });
+
+        it("should show context menu without onRevealInExplorer when only onRemoveSong is provided", async () => {
+            const user = userEvent.setup();
+            render(
+                <SongRow
+                    song={new Song("song.mp3")}
+                    isSelected={false}
+                    isPlaying={false}
+                    onSelect={mockOnSelect}
+                    onPlay={mockOnPlay}
+                    onRemoveSong={vi.fn()}
+                />
+            );
+            const row = screen.getByText("song.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            expect(screen.getByText("Eliminar de la lista")).toBeInTheDocument();
+            expect(screen.queryByText("Mostrar en el Explorador")).not.toBeInTheDocument();
+        });
+
+        it("should call onRemoveSong with the song when Eliminar option is clicked", async () => {
+            const user = userEvent.setup();
+            const mockOnRemoveSong = vi.fn();
+            const song = new Song("song.mp3");
+            render(
+                <SongRow
+                    song={song}
+                    isSelected={false}
+                    isPlaying={false}
+                    onSelect={mockOnSelect}
+                    onPlay={mockOnPlay}
+                    onRemoveSong={mockOnRemoveSong}
+                />
+            );
+            const row = screen.getByText("song.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            await user.click(screen.getByText("Eliminar de la lista"));
+            expect(mockOnRemoveSong).toHaveBeenCalledWith(song);
+        });
+
+        it("should disable 'Eliminar de la lista' when the song is currently playing", async () => {
+            const user = userEvent.setup();
+            render(
+                <SongRow
+                    song={new Song("song.mp3")}
+                    isSelected={false}
+                    isPlaying={false}
+                    isPlayingSong={true}
+                    onSelect={mockOnSelect}
+                    onPlay={mockOnPlay}
+                    onRemoveSong={vi.fn()}
+                />
+            );
+            const row = screen.getByText("song.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            const item = screen.getByText("Eliminar de la lista").closest("li");
+            expect(item?.className).toContain("disabled");
+        });
+
+        it("should enable 'Eliminar de la lista' when the song is not playing", async () => {
+            const user = userEvent.setup();
+            render(
+                <SongRow
+                    song={new Song("song.mp3")}
+                    isSelected={false}
+                    isPlaying={false}
+                    isPlayingSong={false}
+                    onSelect={mockOnSelect}
+                    onPlay={mockOnPlay}
+                    onRemoveSong={vi.fn()}
+                />
+            );
+            const row = screen.getByText("song.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            const item = screen.getByText("Eliminar de la lista").closest("li");
+            expect(item?.className).not.toContain("disabled");
+        });
+
+        it("should show both options when both onRemoveSong and onRevealInExplorer are provided", async () => {
+            const user = userEvent.setup();
+            render(
+                <SongRow
+                    song={new Song("song.mp3")}
+                    isSelected={false}
+                    isPlaying={false}
+                    onSelect={mockOnSelect}
+                    onPlay={mockOnPlay}
+                    onRemoveSong={vi.fn()}
                     onRevealInExplorer={vi.fn()}
                 />
             );
-            const row = container.querySelector("tr");
+            const row = screen.getByText("song.mp3").closest("tr");
             await user.pointer([{ keys: "[MouseRight]", target: row! }]);
-            const item = screen.getByText("Mostrar en el Explorador").closest("li");
-            expect(item?.className).toContain("disabled");
+            expect(screen.getByText("Eliminar de la lista")).toBeInTheDocument();
+            expect(screen.getByText("Mostrar en el Explorador")).toBeInTheDocument();
         });
     });
 });

--- a/test/components/songList/SongRow.test.tsx
+++ b/test/components/songList/SongRow.test.tsx
@@ -228,6 +228,25 @@ describe("SongRow", () => {
             expect(screen.queryByText("Mostrar en el Explorador")).not.toBeInTheDocument();
         });
 
+        it("should disable 'Mostrar en el Explorador' when song is invalid", async () => {
+            const user = userEvent.setup();
+            const invalidSong = new Song("missing.mp3", false);
+            render(
+                <SongRow
+                    song={invalidSong}
+                    isSelected={false}
+                    isPlaying={false}
+                    onSelect={mockOnSelect}
+                    onPlay={mockOnPlay}
+                    onRevealInExplorer={vi.fn()}
+                />
+            );
+            const row = screen.getByText("missing.mp3").closest("tr");
+            await user.pointer([{ keys: "[MouseRight]", target: row! }]);
+            const item = screen.getByText("Mostrar en el Explorador").closest("li");
+            expect(item?.className).toContain("disabled");
+        });
+
         it("should show context menu with 'Eliminar de la lista' when onRemoveSong is provided", async () => {
             const user = userEvent.setup();
             render(

--- a/test/hooks/usePlaylistState.test.ts
+++ b/test/hooks/usePlaylistState.test.ts
@@ -189,6 +189,132 @@ describe("usePlaylistState", () => {
         });
     });
 
+    describe("removing songs", () => {
+        it("should start with hasUnsavedChanges as false", () => {
+            const { result } = renderHook(() => usePlaylistState());
+
+            expect(result.current.hasUnsavedChanges).toBe(false);
+        });
+
+        it("should remove a song from the playlist", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3"), new Song("song3.mp3")];
+
+            act(() => { result.current.setPlaylist(songs); });
+            act(() => { result.current.removeSong(songs[1]); });
+
+            expect(result.current.playlist).toHaveLength(2);
+            expect(result.current.playlist[0]).toBe(songs[0]);
+            expect(result.current.playlist[1]).toBe(songs[2]);
+        });
+
+        it("should set hasUnsavedChanges to true after removing a song", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3")];
+
+            act(() => { result.current.setPlaylist(songs); });
+            act(() => { result.current.removeSong(songs[0]); });
+
+            expect(result.current.hasUnsavedChanges).toBe(true);
+        });
+
+        it("should reset hasUnsavedChanges to false when loading a new playlist", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3")];
+
+            act(() => { result.current.setPlaylist(songs); });
+            act(() => { result.current.removeSong(songs[0]); });
+            expect(result.current.hasUnsavedChanges).toBe(true);
+
+            act(() => { result.current.setPlaylist([new Song("new1.mp3")]); });
+            expect(result.current.hasUnsavedChanges).toBe(false);
+        });
+
+        it("should keep the selected song when a different song is removed", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3"), new Song("song3.mp3")];
+
+            act(() => {
+                result.current.setPlaylist(songs);
+                result.current.setSelectedSong(songs[0]);
+            });
+
+            act(() => { result.current.removeSong(songs[2]); });
+
+            expect(result.current.selectedSong).toBe(songs[0]);
+        });
+
+        it("should auto-select the next song when the selected song is removed and it is not the last", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3"), new Song("song3.mp3")];
+
+            act(() => {
+                result.current.setPlaylist(songs);
+                result.current.setSelectedSong(songs[0]);
+            });
+
+            act(() => { result.current.removeSong(songs[0]); });
+
+            expect(result.current.selectedSong).toBe(songs[1]);
+        });
+
+        it("should auto-select the previous song when removing the last song in the list", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3"), new Song("song3.mp3")];
+
+            act(() => {
+                result.current.setPlaylist(songs);
+                result.current.setSelectedSong(songs[2]);
+            });
+
+            act(() => { result.current.removeSong(songs[2]); });
+
+            expect(result.current.selectedSong).toBe(songs[1]);
+        });
+
+        it("should set selectedSong to null when removing the only song", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const song = new Song("song1.mp3");
+
+            act(() => { result.current.setPlaylist([song]); });
+            act(() => { result.current.removeSong(song); });
+
+            expect(result.current.selectedSong).toBeNull();
+            expect(result.current.playlist).toHaveLength(0);
+        });
+
+        it("should keep correct navigation after removing a song", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3"), new Song("song3.mp3")];
+
+            act(() => {
+                result.current.setPlaylist(songs);
+                result.current.setSelectedSong(songs[0]);
+            });
+
+            act(() => { result.current.removeSong(songs[0]); });
+
+            // After removal: playlist = [song2, song3], selectedSong = song2 (new index 0)
+            expect(result.current.selectedSong).toBe(songs[1]);
+
+            act(() => { result.current.selectNext(); });
+
+            expect(result.current.selectedSong).toBe(songs[2]);
+        });
+
+        it("should do nothing when removing a song not in the playlist", () => {
+            const { result } = renderHook(() => usePlaylistState());
+            const songs = [new Song("song1.mp3"), new Song("song2.mp3")];
+            const notInList = new Song("other.mp3");
+
+            act(() => { result.current.setPlaylist(songs); });
+            act(() => { result.current.removeSong(notInList); });
+
+            expect(result.current.playlist).toHaveLength(2);
+            expect(result.current.hasUnsavedChanges).toBe(false);
+        });
+    });
+
     describe("edge cases", () => {
         it("should handle replacing playlist while song is selected", () => {
             const { result } = renderHook(() => usePlaylistState());


### PR DESCRIPTION
This pull request introduces two main improvements to the playlist management UI: it adds an "unsaved changes" indicator to the playlist banner and implements the ability to remove songs from the playlist via the UI, including disabling removal while a song is playing. Additionally, it updates the sidebar button labels for better clarity and adds comprehensive tests for the new indicator.

**Playlist Management Enhancements:**

* Added an "unsaved changes" indicator (a dot) to the `PlaylistBanner` component, which appears when there are unsaved changes to the playlist. This is controlled by a new `hasUnsavedChanges` prop, which is tracked in the playlist state and updated when songs are removed. Styles for the indicator were added to `App.css`. [[1]](diffhunk://#diff-e22471f3b1fafcc886b8c278a4ac43a5cdcca7796b6d718cc553f22be671737cR8-R16) [[2]](diffhunk://#diff-e22471f3b1fafcc886b8c278a4ac43a5cdcca7796b6d718cc553f22be671737cR30-R57) [[3]](diffhunk://#diff-e22471f3b1fafcc886b8c278a4ac43a5cdcca7796b6d718cc553f22be671737cR86-R89) [[4]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628R19-R22) [[5]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628R89) [[6]](diffhunk://#diff-15b188bf07728a3dcb82d4ad2b95e419e3db23346858de03f2288fa84d8cb401R4-R9) [[7]](diffhunk://#diff-15b188bf07728a3dcb82d4ad2b95e419e3db23346858de03f2288fa84d8cb401R20-R22) [[8]](diffhunk://#diff-7ebefbf77d2ed234f7405eceea120acf075451683b4dd9f64244aceaacaa1096R13-R22) [[9]](diffhunk://#diff-7ebefbf77d2ed234f7405eceea120acf075451683b4dd9f64244aceaacaa1096R41) [[10]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R17) [[11]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R110-R116) [[12]](diffhunk://#diff-60f5dcfc15327d5dd812d9df394c217efbedb4aa33dca782ed69d39dce811972R613-R621)
* Implemented the ability to remove songs from the playlist. The `removeSong` method is now available in the playlist state and is passed through hooks and components. The song context menu in `SongRow` now includes a "Remove from playlist" option, which is disabled if the song is currently playing. [[1]](diffhunk://#diff-e22471f3b1fafcc886b8c278a4ac43a5cdcca7796b6d718cc553f22be671737cR30-R57) [[2]](diffhunk://#diff-e22471f3b1fafcc886b8c278a4ac43a5cdcca7796b6d718cc553f22be671737cR86-R89) [[3]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628R19-R22) [[4]](diffhunk://#diff-4ec7738ab16a3616d87582102dff7ca23c0de8ccf8f88f4d99cfd72ca20f3628R99) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R27) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R59-R62) [[7]](diffhunk://#diff-7ebefbf77d2ed234f7405eceea120acf075451683b4dd9f64244aceaacaa1096R13-R22) [[8]](diffhunk://#diff-7ebefbf77d2ed234f7405eceea120acf075451683b4dd9f64244aceaacaa1096R57-R61) [[9]](diffhunk://#diff-9a8ee93f14b00a9c3f5f1b6dc4d7897bcfccbdbe4e4674c1935b94b61a2070edR10-R32) [[10]](diffhunk://#diff-9a8ee93f14b00a9c3f5f1b6dc4d7897bcfccbdbe4e4674c1935b94b61a2070edL56-R67)

**UI and Usability Improvements:**

* Updated sidebar collapse/expand button labels from "Expandir sidebar" and "Contraer" to "Expandir Biblioteca" and "Ocultar Biblioteca" for better clarity and localization. [[1]](diffhunk://#diff-09e537030c6dbc4554cde1a229961cb17dcb3eb190d9c1921b82387b52f5d948L118-R118) [[2]](diffhunk://#diff-09e537030c6dbc4554cde1a229961cb17dcb3eb190d9c1921b82387b52f5d948L172-R172)

**Testing:**

* Added new tests to `PlaylistBanner.test.tsx` to verify the correct display of the unsaved changes indicator in various scenarios.

These changes improve user feedback and playlist management, making it easier to see when changes need to be saved and to manage songs within a playlist.