### PR TITLE
feat: implement Parallels path resolution for Mac playlists and add c…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   qa:
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   validate:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   qa:
     uses: ./.github/workflows/ci.yml

--- a/docs/domain/persistence.md
+++ b/docs/domain/persistence.md
@@ -26,6 +26,19 @@ Persistence in the current app covers two separate concerns:
 - Saving is a no-op when there is no known playlist file path.
 - A successful save clears the unsaved-changes flag.
 
+## Parallels Path Resolution (Mac)
+
+- Playlist files may contain Parallels Desktop VM paths of the form `\\Mac\Home\...`.
+  These paths are relative to the user's Mac home directory as seen from a Windows VM running under Parallels.
+- When loading a playlist, if a path of this form does not exist on disk, the app attempts to resolve it
+  by replacing the `\\Mac\Home` prefix with the current user's home directory (via the OS path API).
+- If the resolved path exists, the song is marked valid and uses the resolved path for playback.
+  The original VM-style path is preserved internally for round-trip serialization.
+- When saving, the app writes back the original VM-style paths so the file remains compatible with the Parallels environment.
+- If the home directory is unavailable (e.g., the platform API fails), unresolved Parallels paths are
+  silently marked invalid — no error is surfaced to the user.
+- This behavior is Mac-only and applies only to the `\\Mac\Home` Parallels share.
+
 ## What Is Not Persisted Today
 
 - The currently selected song.
@@ -45,6 +58,9 @@ Persistence in the current app covers two separate concerns:
 - `src/logic/UserSettingsStore.ts`
 - `src/components/sidebar/Sidebar.tsx`
 - `src/logic/FileService.ts`
+- `src/logic/ParallelsPathResolver.ts`
 - `src/hooks/useMusicPlayer.ts`
 - `test/logic/UserSettingsStore.test.ts`
 - `test/hooks/useMusicPlayer.persistence.test.ts`
+- `test/logic/ParallelsPathResolver.test.ts`
+- `test/logic/FileService.parallels.test.ts`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uriyya-music-player-tuari",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Uriyya Music Player",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "com.bhbarquero-dev.uriyya-music-player-tauri",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useState, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { message } from "@tauri-apps/plugin-dialog";
 import { Sidebar } from "@components/sidebar/Sidebar";
 import { Player } from "@components/player/Player";
 import { SongList } from "@components/songList/SongList";
@@ -70,6 +71,7 @@ function App() {
       await loadPlaylist();
     } catch (error) {
       console.error("Failed to load playlist:", error);
+      await message(String(error), { title: "Error al cargar la lista", kind: "error" });
     }
   }, [loadPlaylist]);
 
@@ -81,6 +83,7 @@ function App() {
           await loadPlaylist();
         } catch (error) {
           console.error("Failed to change playlist:", error);
+          await message(String(error), { title: "Error al cargar la lista", kind: "error" });
         }
       });
     } else {
@@ -88,6 +91,7 @@ function App() {
         await loadPlaylist();
       } catch (error) {
         console.error("Failed to change playlist:", error);
+        await message(String(error), { title: "Error al cargar la lista", kind: "error" });
       }
     }
   }, [playingSong, hasUnsavedChanges, loadPlaylist, showUnsavedChangesDialog]);

--- a/src/components/sidebar/SidebarFooter.tsx
+++ b/src/components/sidebar/SidebarFooter.tsx
@@ -31,7 +31,7 @@ export function SidebarFooter({ isCompact = false }: SidebarFooterProps = {}) {
 
     return (
         <div className="sidebar-footer">
-            <div>Uriyya Music Player v0.2.1</div>
+            <div>Uriyya Music Player v0.3.0</div>
             <div>Hecho con ❤️ por <a href="https://github.com/bhbarquero-dev">bhbarquero-dev</a></div>
         </div>
     );

--- a/src/hooks/useMusicPlayer.ts
+++ b/src/hooks/useMusicPlayer.ts
@@ -66,6 +66,7 @@ export function useMusicPlayer(fileService?: FileService) {
             }
         } catch (err) {
             console.error("Failed to load playlist:", err);
+            throw err;
         }
     }, [loadPlaylistFiles, setPlaylistState]);
 

--- a/src/hooks/useMusicPlayer.ts
+++ b/src/hooks/useMusicPlayer.ts
@@ -65,7 +65,6 @@ export function useMusicPlayer(fileService?: FileService) {
                 setCurrentPlaylistPath(result.path);
             }
         } catch (err) {
-            console.error("Failed to load playlist:", err);
             throw err;
         }
     }, [loadPlaylistFiles, setPlaylistState]);

--- a/src/logic/FileService.ts
+++ b/src/logic/FileService.ts
@@ -60,15 +60,15 @@ export class FileService {
                 songPaths.map(async (originalPath) => {
                     const isParallels = isParallelsPath(originalPath);
 
-                    if (!isParallels && await this.fileSystem.exists(originalPath)) {
-                        return new Song(originalPath, true);
+                    if (!isParallels) {
+                        const found = await this.fileSystem.exists(originalPath).catch(() => false);
+                        if (found) return new Song(originalPath, true);
                     }
 
                     if (isParallels && homeDir) {
                         const resolvedPath = resolveParallelsPath(originalPath, homeDir);
-                        if (await this.fileSystem.exists(resolvedPath)) {
-                            return new Song(resolvedPath, true, originalPath);
-                        }
+                        const found = await this.fileSystem.exists(resolvedPath).catch(() => false);
+                        if (found) return new Song(resolvedPath, true, originalPath);
                     }
 
                     return new Song(originalPath, false);

--- a/src/logic/FileService.ts
+++ b/src/logic/FileService.ts
@@ -4,6 +4,7 @@ import { TauriFileDialog } from "./TauriFileDialog";
 import { TauriFileSystem } from "./TauriFileSystem";
 import { Song } from "./Song";
 import { isSupportedAudioPath } from "./audioFormats";
+import { isParallelsPath, resolveParallelsPath } from "./ParallelsPathResolver";
 
 export interface PlaylistData {
     songs: Song[];
@@ -14,10 +15,23 @@ export interface PlaylistData {
 export class FileService {
     private fileDialog: FileDialog;
     private fileSystem: FileSystem;
+    private homeDirFn: () => Promise<string | null>;
 
-    constructor(fileDialog?: FileDialog, fileSystem?: FileSystem) {
+    constructor(
+        fileDialog?: FileDialog,
+        fileSystem?: FileSystem,
+        homeDirFn?: () => Promise<string | null>
+    ) {
         this.fileDialog = fileDialog ?? new TauriFileDialog();
         this.fileSystem = fileSystem ?? new TauriFileSystem();
+        this.homeDirFn = homeDirFn ?? (async () => {
+            try {
+                const { homeDir } = await import("@tauri-apps/api/path");
+                return await homeDir();
+            } catch {
+                return null;
+            }
+        });
     }
 
     public async selectAndReadPlaylist(): Promise<PlaylistData | null> {
@@ -40,11 +54,22 @@ export class FileService {
                 .map((line) => line.trim())
                 .filter((line) => line.length > 0 && isSupportedAudioPath(line));
 
-            // Validate each song file exists
+            const homeDir = await this.homeDirFn();
+
             const songs = await Promise.all(
-                songPaths.map(async (path) => {
-                    const exists = await this.fileSystem.exists(path);
-                    return new Song(path, exists);
+                songPaths.map(async (originalPath) => {
+                    if (await this.fileSystem.exists(originalPath)) {
+                        return new Song(originalPath, true);
+                    }
+
+                    if (homeDir && isParallelsPath(originalPath)) {
+                        const resolvedPath = resolveParallelsPath(originalPath, homeDir);
+                        if (await this.fileSystem.exists(resolvedPath)) {
+                            return new Song(resolvedPath, true, originalPath);
+                        }
+                    }
+
+                    return new Song(originalPath, false);
                 })
             );
 
@@ -57,7 +82,7 @@ export class FileService {
 
     public async savePlaylist(path: string, songs: Song[]): Promise<void> {
         try {
-            const content = songs.map(s => s.getPath()).join('\n');
+            const content = songs.map(s => s.getOriginalPath()).join('\n');
             await this.fileSystem.writeTextFile(path, content);
         } catch (err) {
             console.error("FileService Error:", err);

--- a/src/logic/FileService.ts
+++ b/src/logic/FileService.ts
@@ -58,11 +58,13 @@ export class FileService {
 
             const songs = await Promise.all(
                 songPaths.map(async (originalPath) => {
-                    if (await this.fileSystem.exists(originalPath)) {
+                    const isParallels = isParallelsPath(originalPath);
+
+                    if (!isParallels && await this.fileSystem.exists(originalPath)) {
                         return new Song(originalPath, true);
                     }
 
-                    if (homeDir && isParallelsPath(originalPath)) {
+                    if (isParallels && homeDir) {
                         const resolvedPath = resolveParallelsPath(originalPath, homeDir);
                         if (await this.fileSystem.exists(resolvedPath)) {
                             return new Song(resolvedPath, true, originalPath);

--- a/src/logic/ParallelsPathResolver.ts
+++ b/src/logic/ParallelsPathResolver.ts
@@ -1,0 +1,17 @@
+const PARALLELS_HOME_PREFIX = "\\\\Mac\\Home";
+
+export function isParallelsPath(path: string): boolean {
+    return path.toLowerCase().startsWith(PARALLELS_HOME_PREFIX.toLowerCase());
+}
+
+export function resolveParallelsPath(path: string, homeDir: string): string {
+    const base = homeDir.endsWith("/") ? homeDir.slice(0, -1) : homeDir;
+    const tail = path.slice(PARALLELS_HOME_PREFIX.length).replace(/\\/g, "/");
+    return base + tail;
+}
+
+export function unresolveParallelsPath(path: string, homeDir: string): string {
+    const base = homeDir.endsWith("/") ? homeDir.slice(0, -1) : homeDir;
+    const tail = path.slice(base.length).replace(/\//g, "\\");
+    return PARALLELS_HOME_PREFIX + tail;
+}

--- a/src/logic/ParallelsPathResolver.ts
+++ b/src/logic/ParallelsPathResolver.ts
@@ -1,10 +1,20 @@
 const PARALLELS_HOME_PREFIX = "\\\\Mac\\Home";
 
 export function isParallelsPath(path: string): boolean {
-    return path.toLowerCase().startsWith(PARALLELS_HOME_PREFIX.toLowerCase());
+    const normalizedPath = path.toLowerCase();
+    const normalizedPrefix = PARALLELS_HOME_PREFIX.toLowerCase();
+
+    return (
+        normalizedPath === normalizedPrefix ||
+        normalizedPath.startsWith(normalizedPrefix + "\\")
+    );
 }
 
 export function resolveParallelsPath(path: string, homeDir: string): string {
+    if (!isParallelsPath(path)) {
+        return path;
+    }
+
     const base = homeDir.endsWith("/") ? homeDir.slice(0, -1) : homeDir;
     const tail = path.slice(PARALLELS_HOME_PREFIX.length).replace(/\\/g, "/");
     return base + tail;
@@ -12,6 +22,15 @@ export function resolveParallelsPath(path: string, homeDir: string): string {
 
 export function unresolveParallelsPath(path: string, homeDir: string): string {
     const base = homeDir.endsWith("/") ? homeDir.slice(0, -1) : homeDir;
+
+    if (path === base) {
+        return PARALLELS_HOME_PREFIX;
+    }
+
+    if (!path.startsWith(base + "/")) {
+        return path;
+    }
+
     const tail = path.slice(base.length).replace(/\//g, "\\");
     return PARALLELS_HOME_PREFIX + tail;
 }

--- a/src/logic/Song.ts
+++ b/src/logic/Song.ts
@@ -7,7 +7,8 @@ export class Song {
 
     constructor(
         path: string,
-        private readonly valid: boolean = true
+        private readonly valid: boolean = true,
+        private readonly originalPath?: string
     ) {
         const normalizedPath = path.trim();
 
@@ -31,6 +32,10 @@ export class Song {
 
     public getPath(): string {
         return this.path;
+    }
+
+    public getOriginalPath(): string {
+        return this.originalPath ?? this.path;
     }
 
     public isValid(): boolean {

--- a/src/logic/Song.ts
+++ b/src/logic/Song.ts
@@ -1,6 +1,15 @@
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { isSupportedAudioPath, SUPPORTED_AUDIO_EXTENSIONS } from "./audioFormats";
 
+function generateUUID(): string {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40; // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant
+    const hex = Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("");
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 export class Song {
     private readonly id: string;
     private readonly path: string;
@@ -26,7 +35,7 @@ export class Song {
         }
 
         this.path = normalizedPath;
-        this.id = crypto.randomUUID();
+        this.id = generateUUID();
     }
 
     public getId(): string {

--- a/src/logic/Song.ts
+++ b/src/logic/Song.ts
@@ -5,11 +5,14 @@ export class Song {
     private readonly id: string;
     private readonly path: string;
 
+    private readonly originalPath?: string;
+
     constructor(
         path: string,
         private readonly valid: boolean = true,
-        private readonly originalPath?: string
+        originalPath?: string
     ) {
+        this.originalPath = originalPath?.trim();
         const normalizedPath = path.trim();
 
         if (!normalizedPath) {

--- a/src/logic/Song.ts
+++ b/src/logic/Song.ts
@@ -21,7 +21,8 @@ export class Song {
         private readonly valid: boolean = true,
         originalPath?: string
     ) {
-        this.originalPath = originalPath?.trim();
+        const normalizedOriginalPath = originalPath?.trim();
+        this.originalPath = normalizedOriginalPath || undefined;
         const normalizedPath = path.trim();
 
         if (!normalizedPath) {

--- a/test/logic/FileService.parallels.test.ts
+++ b/test/logic/FileService.parallels.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from "vitest";
+import { FileService } from "../../src/logic/FileService";
+import { FileDialog } from "../../src/abstractions/FileDialog";
+import { FileSystem } from "../../src/abstractions/FileSystem";
+import { Song } from "../../src/logic/Song";
+
+const HOME_DIR = "/Users/uriyya";
+const VM_PATH = "\\\\Mac\\Home\\Music\\file.mp3";
+const RESOLVED_PATH = "/Users/uriyya/Music/file.mp3";
+
+describe("FileService - Parallels path resolution", () => {
+    it("resolves a Parallels path when homeDir is available and resolved file exists", async () => {
+        const mockDialog: FileDialog = {
+            open: vi.fn().mockResolvedValue("C:\\playlist.alb"),
+            openDirectory: vi.fn().mockResolvedValue(null),
+        };
+        const mockFileSystem: FileSystem = {
+            readTextFile: vi.fn().mockResolvedValue(`${VM_PATH}\n`),
+            exists: vi.fn()
+                .mockResolvedValueOnce(false)  // exact VM path does not exist
+                .mockResolvedValueOnce(true),  // resolved Mac path exists
+            writeTextFile: vi.fn(),
+        };
+        const homeDirFn = vi.fn().mockResolvedValue(HOME_DIR);
+
+        const service = new FileService(mockDialog, mockFileSystem, homeDirFn);
+        const result = await service.selectAndReadPlaylist();
+
+        expect(result?.songs).toHaveLength(1);
+        const song = result!.songs[0];
+        expect(song.isValid()).toBe(true);
+        expect(song.getPath()).toBe(RESOLVED_PATH);
+        expect(song.getOriginalPath()).toBe(VM_PATH);
+    });
+
+    it("keeps song invalid when homeDir is null (graceful degradation)", async () => {
+        const mockDialog: FileDialog = {
+            open: vi.fn().mockResolvedValue("C:\\playlist.alb"),
+            openDirectory: vi.fn().mockResolvedValue(null),
+        };
+        const mockFileSystem: FileSystem = {
+            readTextFile: vi.fn().mockResolvedValue(`${VM_PATH}\n`),
+            exists: vi.fn().mockResolvedValue(false),
+            writeTextFile: vi.fn(),
+        };
+        const homeDirFn = vi.fn().mockResolvedValue(null);
+
+        const service = new FileService(mockDialog, mockFileSystem, homeDirFn);
+        const result = await service.selectAndReadPlaylist();
+
+        expect(result?.songs[0].isValid()).toBe(false);
+        expect(result?.songs[0].getPath()).toBe(VM_PATH);
+        expect(result?.songs[0].getOriginalPath()).toBe(VM_PATH);
+    });
+
+    it("keeps song invalid when Parallels path does not exist even after resolution", async () => {
+        const mockDialog: FileDialog = {
+            open: vi.fn().mockResolvedValue("C:\\playlist.alb"),
+            openDirectory: vi.fn().mockResolvedValue(null),
+        };
+        const mockFileSystem: FileSystem = {
+            readTextFile: vi.fn().mockResolvedValue(`${VM_PATH}\n`),
+            exists: vi.fn().mockResolvedValue(false),
+            writeTextFile: vi.fn(),
+        };
+        const homeDirFn = vi.fn().mockResolvedValue(HOME_DIR);
+
+        const service = new FileService(mockDialog, mockFileSystem, homeDirFn);
+        const result = await service.selectAndReadPlaylist();
+
+        expect(result?.songs[0].isValid()).toBe(false);
+    });
+
+    it("does not attempt resolution for non-Parallels paths", async () => {
+        const nativePath = "/Users/uriyya/Music/native.mp3";
+        const mockDialog: FileDialog = {
+            open: vi.fn().mockResolvedValue("C:\\playlist.alb"),
+            openDirectory: vi.fn().mockResolvedValue(null),
+        };
+        const mockFileSystem: FileSystem = {
+            readTextFile: vi.fn().mockResolvedValue(`${nativePath}\n`),
+            exists: vi.fn().mockResolvedValue(true),
+            writeTextFile: vi.fn(),
+        };
+        const homeDirFn = vi.fn().mockResolvedValue(HOME_DIR);
+
+        const service = new FileService(mockDialog, mockFileSystem, homeDirFn);
+        const result = await service.selectAndReadPlaylist();
+
+        expect(result?.songs[0].isValid()).toBe(true);
+        expect(result?.songs[0].getPath()).toBe(nativePath);
+        expect(result?.songs[0].getOriginalPath()).toBe(nativePath);
+        // exists called only once — no second lookup for resolution
+        expect(mockFileSystem.exists).toHaveBeenCalledTimes(1);
+    });
+
+    it("savePlaylist writes original VM paths, not the resolved Mac paths", async () => {
+        const mockDialog: FileDialog = {
+            open: vi.fn(),
+            openDirectory: vi.fn(),
+        };
+        const mockFileSystem: FileSystem = {
+            readTextFile: vi.fn(),
+            exists: vi.fn(),
+            writeTextFile: vi.fn().mockResolvedValue(undefined),
+        };
+        const songs = [new Song(RESOLVED_PATH, true, VM_PATH)];
+        const service = new FileService(mockDialog, mockFileSystem);
+
+        await service.savePlaylist("C:\\playlist.alb", songs);
+
+        expect(mockFileSystem.writeTextFile).toHaveBeenCalledWith(
+            "C:\\playlist.alb",
+            VM_PATH
+        );
+    });
+});

--- a/test/logic/FileService.parallels.test.ts
+++ b/test/logic/FileService.parallels.test.ts
@@ -16,9 +16,7 @@ describe("FileService - Parallels path resolution", () => {
         };
         const mockFileSystem: FileSystem = {
             readTextFile: vi.fn().mockResolvedValue(`${VM_PATH}\n`),
-            exists: vi.fn()
-                .mockResolvedValueOnce(false)  // exact VM path does not exist
-                .mockResolvedValueOnce(true),  // resolved Mac path exists
+            exists: vi.fn().mockResolvedValue(true),  // resolved Mac path exists
             writeTextFile: vi.fn(),
         };
         const homeDirFn = vi.fn().mockResolvedValue(HOME_DIR);
@@ -31,6 +29,9 @@ describe("FileService - Parallels path resolution", () => {
         expect(song.isValid()).toBe(true);
         expect(song.getPath()).toBe(RESOLVED_PATH);
         expect(song.getOriginalPath()).toBe(VM_PATH);
+        // exists is called only once — with the resolved Mac path, never with the raw VM path
+        expect(mockFileSystem.exists).toHaveBeenCalledTimes(1);
+        expect(mockFileSystem.exists).toHaveBeenCalledWith(RESOLVED_PATH);
     });
 
     it("keeps song invalid when homeDir is null (graceful degradation)", async () => {

--- a/test/logic/ParallelsPathResolver.test.ts
+++ b/test/logic/ParallelsPathResolver.test.ts
@@ -27,6 +27,14 @@ describe("ParallelsPathResolver", () => {
         it("returns false for a Windows absolute path", () => {
             expect(isParallelsPath("C:\\Users\\user\\Music\\file.mp3")).toBe(false);
         });
+
+        it("returns false for a path starting with \\\\Mac\\Home2", () => {
+            expect(isParallelsPath("\\\\Mac\\Home2\\Music\\file.mp3")).toBe(false);
+        });
+
+        it("returns true for a path exactly equal to the prefix", () => {
+            expect(isParallelsPath("\\\\Mac\\Home")).toBe(true);
+        });
     });
 
     describe("resolveParallelsPath", () => {
@@ -50,6 +58,12 @@ describe("ParallelsPathResolver", () => {
                 resolveParallelsPath("\\\\Mac\\Home\\Music\\file.mp3", "/Users/uriyya/")
             ).toBe("/Users/uriyya/Music/file.mp3");
         });
+
+        it("returns the path unchanged when it is not a Parallels path", () => {
+            expect(
+                resolveParallelsPath("/Users/uriyya/Music/file.mp3", "/Users/uriyya")
+            ).toBe("/Users/uriyya/Music/file.mp3");
+        });
     });
 
     describe("unresolveParallelsPath", () => {
@@ -65,6 +79,18 @@ describe("ParallelsPathResolver", () => {
             expect(
                 unresolveParallelsPath(resolveParallelsPath(original, homeDir), homeDir)
             ).toBe(original);
+        });
+
+        it("returns the path unchanged when it does not start with homeDir", () => {
+            expect(
+                unresolveParallelsPath("/Other/path/file.mp3", "/Users/uriyya")
+            ).toBe("/Other/path/file.mp3");
+        });
+
+        it("returns PARALLELS_HOME_PREFIX when path equals homeDir exactly", () => {
+            expect(
+                unresolveParallelsPath("/Users/uriyya", "/Users/uriyya")
+            ).toBe("\\\\Mac\\Home");
         });
     });
 });

--- a/test/logic/ParallelsPathResolver.test.ts
+++ b/test/logic/ParallelsPathResolver.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+    isParallelsPath,
+    resolveParallelsPath,
+    unresolveParallelsPath,
+} from "../../src/logic/ParallelsPathResolver";
+
+describe("ParallelsPathResolver", () => {
+    describe("isParallelsPath", () => {
+        it("detects a standard \\\\Mac\\Home path", () => {
+            expect(isParallelsPath("\\\\Mac\\Home\\Music\\file.mp3")).toBe(true);
+        });
+
+        it("is case-insensitive on the prefix", () => {
+            expect(isParallelsPath("\\\\mac\\home\\Music\\file.mp3")).toBe(true);
+            expect(isParallelsPath("\\\\MAC\\HOME\\Music\\file.mp3")).toBe(true);
+        });
+
+        it("returns false for a native Mac path", () => {
+            expect(isParallelsPath("/Users/uriyya/Music/file.mp3")).toBe(false);
+        });
+
+        it("returns false for a plain filename", () => {
+            expect(isParallelsPath("file.mp3")).toBe(false);
+        });
+
+        it("returns false for a Windows absolute path", () => {
+            expect(isParallelsPath("C:\\Users\\user\\Music\\file.mp3")).toBe(false);
+        });
+    });
+
+    describe("resolveParallelsPath", () => {
+        it("replaces \\\\Mac\\Home with homeDir and converts backslashes to forward slashes", () => {
+            expect(
+                resolveParallelsPath("\\\\Mac\\Home\\Music\\file.mp3", "/Users/uriyya")
+            ).toBe("/Users/uriyya/Music/file.mp3");
+        });
+
+        it("handles nested subdirectories", () => {
+            expect(
+                resolveParallelsPath(
+                    "\\\\Mac\\Home\\Music\\SubDir\\Another Dir\\file.mp3",
+                    "/Users/uriyya"
+                )
+            ).toBe("/Users/uriyya/Music/SubDir/Another Dir/file.mp3");
+        });
+
+        it("strips a trailing slash from homeDir before joining", () => {
+            expect(
+                resolveParallelsPath("\\\\Mac\\Home\\Music\\file.mp3", "/Users/uriyya/")
+            ).toBe("/Users/uriyya/Music/file.mp3");
+        });
+    });
+
+    describe("unresolveParallelsPath", () => {
+        it("replaces homeDir prefix with \\\\Mac\\Home and converts forward slashes to backslashes", () => {
+            expect(
+                unresolveParallelsPath("/Users/uriyya/Music/file.mp3", "/Users/uriyya")
+            ).toBe("\\\\Mac\\Home\\Music\\file.mp3");
+        });
+
+        it("round-trips correctly with resolveParallelsPath", () => {
+            const original = "\\\\Mac\\Home\\Music\\SubDir\\file.mp3";
+            const homeDir = "/Users/uriyya";
+            expect(
+                unresolveParallelsPath(resolveParallelsPath(original, homeDir), homeDir)
+            ).toBe(original);
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,12 +15,11 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
-      "@components/player": ["src/components/player"],
-      "@components/songList": ["src/components/songList"],
-      "@components/sidebar": ["src/components/sidebar"],
-      "@components/*": ["src/components/*"]
+      "@components/player": ["./src/components/player"],
+      "@components/songList": ["./src/components/songList"],
+      "@components/sidebar": ["./src/components/sidebar"],
+      "@components/*": ["./src/components/*"]
     },
 
     /* Linting */


### PR DESCRIPTION
This pull request adds support for resolving Parallels Desktop VM-style paths (e.g., `\Mac\Home\...`) in playlists on Mac, ensuring that music files referenced from a Windows VM can be located and played back on the host Mac. It also ensures that when saving playlists, the original VM-style paths are preserved for compatibility. The implementation includes new logic, tests, and documentation updates.

**Parallels path resolution (Mac-only):**
* Added a new module `ParallelsPathResolver` with functions to detect and resolve Parallels VM paths to the Mac home directory, and to reverse the process for saving (`src/logic/ParallelsPathResolver.ts`).
* Updated `FileService` to use Parallels path resolution when loading playlists: if a VM-style path does not exist on disk, the service attempts to resolve it using the user's home directory, and marks the song as valid if found. When saving, it writes the original VM-style paths back to the playlist file (`src/logic/FileService.ts`). [[1]](diffhunk://#diff-45f08f78c60373ffd451032f96e3c283f1b853fd4f1e5c6d7f960c10a71b1394R7) [[2]](diffhunk://#diff-45f08f78c60373ffd451032f96e3c283f1b853fd4f1e5c6d7f960c10a71b1394R18-R34) [[3]](diffhunk://#diff-45f08f78c60373ffd451032f96e3c283f1b853fd4f1e5c6d7f960c10a71b1394L43-R72) [[4]](diffhunk://#diff-45f08f78c60373ffd451032f96e3c283f1b853fd4f1e5c6d7f960c10a71b1394L60-R85)

**Enhancements to the `Song` class:**
* Updated the `Song` class to track both the resolved path (used for playback) and the original path (used for saving and round-trip serialization), with a new method `getOriginalPath()` (`src/logic/Song.ts`). [[1]](diffhunk://#diff-9f71a68c3ac0c0f7a2f099d8d195e6f87e5606192461859134cd1e3455ecad5fL10-R11) [[2]](diffhunk://#diff-9f71a68c3ac0c0f7a2f099d8d195e6f87e5606192461859134cd1e3455ecad5fR37-R40)

**Testing:**
* Added unit tests for Parallels path resolution logic (`test/logic/ParallelsPathResolver.test.ts`).
* Added integration tests for `FileService` to cover Parallels path handling, including edge cases (missing home directory, non-Parallels paths, and round-trip save/load) (`test/logic/FileService.parallels.test.ts`).

**Documentation:**
* Updated the persistence documentation to describe Parallels path resolution behavior and list the new/modified files and tests (`docs/domain/persistence.md`). [[1]](diffhunk://#diff-bced47171501917956cdf878b340940c483c90fd5a3d84f183d4d4fac8a1bfdfR29-R41) [[2]](diffhunk://#diff-bced47171501917956cdf878b340940c483c90fd5a3d84f183d4d4fac8a1bfdfR61-R66)…orresponding tests