### PR TITLE
feat: add permission for writing to $APPCONFIG directory

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -38,18 +38,10 @@
       ]
     },
     {
-      "identifier": "fs:allow-write-text-file",
-      "allow": [
-        {
-          "path": "**"
-        }
-      ]
-    },
-    {
       "identifier": "fs:allow-write-file",
       "allow": [
         {
-          "path": "$APPCONFIG/**"
+          "path": "**"
         }
       ]
     }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -44,6 +44,14 @@
           "path": "**"
         }
       ]
+    },
+    {
+      "identifier": "fs:allow-write-file",
+      "allow": [
+        {
+          "path": "$APPCONFIG/**"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This pull request adds a new capability to the `src-tauri/capabilities/default.json` file, allowing write access to files within the `$APPCONFIG` directory.

Filesystem access:

* Added a new capability entry `fs:allow-write-file` that allows writing to any file under the `$APPCONFIG` directory.